### PR TITLE
- upgrade to Gradle/API 28/AndroidX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/sample/TORGIListener/build.gradle
+++ b/sample/TORGIListener/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/torgi/build.gradle
+++ b/torgi/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES.txt'
@@ -11,15 +11,10 @@ android {
     defaultConfig {
         applicationId "org.sofwerx.torgi"
         minSdkVersion 24
-        targetSdkVersion 27
-        versionCode 5
-        versionName "1.2"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        externalNativeBuild {
-            cmake {
-                cppFlags ""
-            }
-        }
+        targetSdkVersion 28
+        versionCode 6
+        versionName "1.2.3"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -27,11 +22,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-//    externalNativeBuild {
-//        cmake {
-//            path "CMakeLists.txt"
-//        }
-//    }
     flavorDimensions "version"
     productFlavors {
         logger {
@@ -53,20 +43,17 @@ android {
 }
 
 dependencies {
-    //implementation fileTree(include: ['*.jar'], dir: 'libs')
-    //implementation project(':geopackage-sdk')
-
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    viewerImplementation 'com.github.PhilJay:MPAndroidChart:v3.0.3' //for charts
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha3'
+    implementation 'androidx.appcompat:appcompat:1.1.0-alpha01'
+    implementation 'com.google.android.material:material:1.1.0-alpha02'
+    viewerImplementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha3'
+    viewerImplementation 'com.github.PhilJay:MPAndroidChart:v3.1.0-alpha' //for charts
     viewerImplementation 'org.osmdroid:osmdroid-android:6.0.2'
     implementation 'org.apache.httpcomponents:httpclient:4.5.6' //for SOS server
     implementation 'org.nanohttpd:nanohttpd:2.3.1' //for SOS server
     implementation 'org.apache.commons:commons-math3:3.6.1' //for statistical analysis
-    implementation 'mil.nga.geopackage:geopackage-android:3.0.2'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    viewerImplementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation 'com.android.support:design:27.1.1'
+    implementation 'mil.nga.geopackage:geopackage-android:3.1.0'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
 }

--- a/torgi/src/androidTest/java/org/sofwerx/torgi/ExampleInstrumentedTest.java
+++ b/torgi/src/androidTest/java/org/sofwerx/torgi/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package org.sofwerx.signalmonitor;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/torgi/src/main/AndroidManifest.xml
+++ b/torgi/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-feature android:name="android.hardware.location.gps" />
 
@@ -33,7 +34,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".ui.SettingsActivity" />
+        <activity android:name=".ui.SettingsActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MANAGE_NETWORK_USAGE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
 
     </application>
 

--- a/torgi/src/main/java/org/sofwerx/torgi/GeoPackageFileProvider.java
+++ b/torgi/src/main/java/org/sofwerx/torgi/GeoPackageFileProvider.java
@@ -1,5 +1,5 @@
 package org.sofwerx.torgi;
 
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 
 public class GeoPackageFileProvider extends FileProvider {}

--- a/torgi/src/main/java/org/sofwerx/torgi/gnss/EWIndicators.java
+++ b/torgi/src/main/java/org/sofwerx/torgi/gnss/EWIndicators.java
@@ -46,7 +46,6 @@ public class EWIndicators {
                 if (total > 1f)
                     total = 1f;
                 return total;
-                //return Math.max(likelihoodRFI, fusedSpoofing);
             }
         } else
             return likelihoodRFI;

--- a/torgi/src/main/java/org/sofwerx/torgi/listener/GeoPackageRetrievalListener.java
+++ b/torgi/src/main/java/org/sofwerx/torgi/listener/GeoPackageRetrievalListener.java
@@ -1,8 +1,5 @@
 package org.sofwerx.torgi.listener;
 
-import android.location.GnssMeasurement;
-import android.support.annotation.NonNull;
-
 import org.sofwerx.torgi.gnss.helper.GeoPackageGPSPtHelper;
 import org.sofwerx.torgi.gnss.helper.GeoPackageSatDataHelper;
 

--- a/torgi/src/main/java/org/sofwerx/torgi/service/GeoPackageRecorder.java
+++ b/torgi/src/main/java/org/sofwerx/torgi/service/GeoPackageRecorder.java
@@ -124,7 +124,6 @@ public class GeoPackageRecorder extends HandlerThread {
     private final static String SAT_DATA_CONSTELLATION = "constellation";
     private final static String SAT_DATA_CN0 = "cn0";
     private final static String SAT_DATA_AGC = "agc";
-    //private final static String SAT_DATA_SAT_TIME_NANOS = "sat_time_nanos";
 
     private final static String GPS_OBS_PT_LAT = "Lat";
     private final static String GPS_OBS_PT_LNG = "Lon";
@@ -400,7 +399,7 @@ public class GeoPackageRecorder extends HandlerThread {
      * over OGC SOS GetObservation) and puts it in the geopackage
      * TODO
      * This has a lot of duplicate code for the onGnssMeasurementReceived call, so it would be a good
-     * idea to create an class that could handle both - otherwise there's a significant risk of gettting
+     * idea to create an class that could handle both - otherwise there's a significant risk of getting
      * out of sync when the GeoPackage structure is changed
      */
     public void onGeoPackageSatDataHelperReceived(ArrayList<GeoPackageSatDataHelper> data) {
@@ -543,7 +542,7 @@ public class GeoPackageRecorder extends HandlerThread {
                                 satrow.setValue("agc", g.getAutomaticGainControlLevelDb());
                                 satrow.setValue("has_agc", 1);
                             } else {
-                                satrow.setValue("agc", 0);
+                                satrow.setValue("agc", 0d);
                                 satrow.setValue("has_agc", 0);
                             }
                         } else {
@@ -586,8 +585,8 @@ public class GeoPackageRecorder extends HandlerThread {
                             satrow.setValue("has_ephemeris", 0);
                             satrow.setValue("has_carrier_freq", 0);
 
-                            satrow.setValue("elevation_deg", 0.0);
-                            satrow.setValue("azimuth_deg", 0.0);
+                            satrow.setValue("elevation_deg", 0.0d);
+                            satrow.setValue("azimuth_deg", 0.0d);
                         }
 
                         satrow.setValue("data_dump", g.toString());
@@ -615,8 +614,6 @@ public class GeoPackageRecorder extends HandlerThread {
                 if ((values != null) && (values.length > 0)) {
                     UserCustomDao sensorDao = RTE.getUserDao(motionTblName);
                     UserCustomRow sensorRow = sensorDao.newRow();
-                    //SimpleAttributesDao sensorDao = RTE.getSimpleAttributesDao(motionTblName);
-                    //SimpleAttributesRow sensorRow = sensorDao.newRow();
                     for (int i=1;i<sensorRow.columnCount();i++) {
                         sensorRow.setValue(i,0d);
                     }
@@ -917,7 +914,7 @@ public class GeoPackageRecorder extends HandlerThread {
 
                         SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.US);
                         df.setTimeZone(TimeZone.getTimeZone("UTC")); //needed so geopackage can handle timezone correctly
-                        String formattedDate = df.format(st.getTime())+"Z"; //FIXME this is a little hackish, but the geopackage tools apparently have a hard time dealing with anything other than UTC timezone and it must be designated with "Z" rather than "UTC"
+                        String formattedDate = df.format(st.getTime())+"Z"; //this is a little hackish, but the geopackage tools apparently have a hard time dealing with anything other than UTC timezone and it must be designated with "Z" rather than "UTC"
                         frow.setValue("SysTime", formattedDate);
                         frow.setValue("HasVerticalAccuracy", 0);
                         frow.setValue("VerticalAccuracy", 0d);

--- a/torgi/src/main/java/org/sofwerx/torgi/service/SensorService.java
+++ b/torgi/src/main/java/org/sofwerx/torgi/service/SensorService.java
@@ -86,7 +86,5 @@ public class SensorService implements SensorEventListener {
     }
 
     @Override
-    public void onAccuracyChanged(Sensor sensor, int accuracy) {
-        //ignore
-    }
+    public void onAccuracyChanged(Sensor sensor, int accuracy) { /*ignored */ }
 }

--- a/torgi/src/main/java/org/sofwerx/torgi/ui/AbstractTORGIActivity.java
+++ b/torgi/src/main/java/org/sofwerx/torgi/ui/AbstractTORGIActivity.java
@@ -11,7 +11,6 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
-import android.location.Location;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -19,8 +18,8 @@ import android.os.IBinder;
 import android.os.PowerManager;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -29,7 +28,6 @@ import android.widget.Toast;
 
 import org.sofwerx.torgi.Config;
 import org.sofwerx.torgi.R;
-import org.sofwerx.torgi.gnss.LatLng;
 import org.sofwerx.torgi.listener.GnssMeasurementListener;
 import org.sofwerx.torgi.service.TorgiService;
 

--- a/torgi/src/main/res/layout/dialog_source.xml
+++ b/torgi/src/main/res/layout/dialog_source.xml
@@ -52,7 +52,7 @@
             android:layout_toEndOf="@id/sourceImageNetwork"
             android:layout_alignParentTop="true"/>
 
-        <android.support.design.widget.TextInputLayout
+        <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/sourceNetworkIPLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -64,6 +64,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/source_network_hint"/>
-        </android.support.design.widget.TextInputLayout>
+        </com.google.android.material.textfield.TextInputLayout>
     </RelativeLayout>
 </LinearLayout>

--- a/torgi/src/viewer/java/org/sofwerx/torgi/ui/DialogSourceSelect.java
+++ b/torgi/src/viewer/java/org/sofwerx/torgi/ui/DialogSourceSelect.java
@@ -1,10 +1,9 @@
 package org.sofwerx.torgi.ui;
 
-import android.app.Activity;
 import android.app.AlertDialog;
-import android.content.DialogInterface;
-import android.support.annotation.NonNull;
-import android.support.design.widget.TextInputLayout;
+
+import androidx.annotation.NonNull;
+import com.google.android.material.textfield.TextInputLayout;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;

--- a/torgi/src/viewer/java/org/sofwerx/torgi/ui/GNSSStatusView.java
+++ b/torgi/src/viewer/java/org/sofwerx/torgi/ui/GNSSStatusView.java
@@ -16,6 +16,7 @@ import android.widget.TextView;
 import org.sofwerx.torgi.R;
 
 public class GNSSStatusView extends RelativeLayout {
+    private final static long DELAY_TO_REDUCE_WARNING = 1000l * 60l; //provides a waiting period (milliseconds) before the warning level is allowed to be reduced
     private boolean showText = false;
     public final static int STATUS_DISABLED = -1;
     private int warnPercent = STATUS_DISABLED;
@@ -23,6 +24,7 @@ public class GNSSStatusView extends RelativeLayout {
     private TextView label;
     private final static int LOW_RISK_CAP = 15;
     private final static int MEDIUM_RISK_CAP = 45;
+    private long nextDowngradeEligibleTime = Long.MIN_VALUE;
     private final Context context;
 
     public GNSSStatusView(Context context) {
@@ -73,6 +75,12 @@ public class GNSSStatusView extends RelativeLayout {
 
     public void setWarnPercent(int warnPercent) {
         if (this.warnPercent != warnPercent) {
+            if (warnPercent < this.warnPercent) {
+                //ignore this update if still in the warning period for the last elevated warning level
+                if (System.currentTimeMillis() < nextDowngradeEligibleTime)
+                    return;
+            } else
+                nextDowngradeEligibleTime = System.currentTimeMillis() + DELAY_TO_REDUCE_WARNING;
             if (this.warnPercent < 0)
                 blackBar.setVisibility(View.VISIBLE);
             else if (warnPercent < 0) {

--- a/torgi/src/viewer/res/layout/about_activity.xml
+++ b/torgi/src/viewer/res/layout/about_activity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:android="http://schemas.android.com/apk/res/android"
@@ -122,4 +122,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Bring code current and clean up a bit ahead of the next phase of improvements.

- upgrade to Gradle 4.6 / 3.2.1
- upgrade to API 28 and address API 28 related error corrections
- upgrade from support library to AndroidX
- minor graphing GUI improvements
- improved error handling when AGC values are not available